### PR TITLE
Allow dns_owner user to read and write dns directory

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,13 @@
 ---
 # handlers file for dns
+- name: set dns_owner to owner of dns directory recursively
+  file:
+    path: "{{ dns_confdir }}"
+    owner: "{{ dns_owner }}"
+    group: "{{ dns_group }}"
+    mode: 0640
+    recurse: true
+
 - name: reload zones
   command: rndc reload
   when:
@@ -9,11 +17,3 @@
   command: rndc reload
   when:
     - ansible_virtualization_type != "docker" or dns_ignore_docker
-
-- name: set dns_owner to owner of dns directory recursively
-  file:
-    path: "{{ dns_confdir }}"
-    owner: "{{ dns_owner }}"
-    group: "{{ dns_group }}"
-    mode: 0640
-    recurse: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,5 +15,5 @@
     path: "{{ dns_confdir }}"
     owner: "{{ dns_owner }}"
     group: "{{ dns_group }}"
-    mode: 0644
+    mode: 0640
     recurse: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -14,6 +14,6 @@
   file:
     path: "{{ dns_confdir }}"
     owner: "{{ dns_owner }}"
-    group: "{{ dns_owner }}"
+    group: "{{ dns_group }}"
     mode: 0644
     recurse: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: reload zones
   command: rndc reload
   when:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,5 @@
 ---
+# handlers file for dns
 - name: reload zones
   command: rndc reload
   when:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,3 +9,11 @@
   command: rndc reload
   when:
     - ansible_virtualization_type != "docker" or dns_ignore_docker
+
+- name: set dns_owner to owner of dns directory recursively
+  file:
+    path: "{{ dns_confdir }}"
+    owner: "{{ dns_owner }}"
+    group: "{{ dns_owner }}"
+    mode: 0644
+    recurse: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,12 +1,4 @@
 ---
-# handlers file for dns
-- name: set dns_owner to owner of dns directory recursively
-  file:
-    path: "{{ dns_confdir }}"
-    owner: "{{ dns_owner }}"
-    group: "{{ dns_group }}"
-    mode: 0640
-    recurse: true
 
 - name: reload zones
   command: rndc reload

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,7 +53,7 @@
     dest: "{{ dns_datadir }}/{{ item.name }}.conf"
   with_items:
     - "{{ dns_zones }}"
-  notify:   
+  notify:
     - set dns_owner to owner of dns directory recursively
     - reload zones
   loop_control:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -58,7 +58,6 @@
     - set dns_owner to owner of dns directory recursively
   loop_control:
     label: "{{ item.name }}"
-    
 
 - name: add zones to configuration
   template:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,9 +53,9 @@
     dest: "{{ dns_datadir }}/{{ item.name }}.conf"
   with_items:
     - "{{ dns_zones }}"
-  notify:
-    - reload zones
+  notify:   
     - set dns_owner to owner of dns directory recursively
+    - reload zones
   loop_control:
     label: "{{ item.name }}"
 
@@ -65,8 +65,8 @@
     dest: "{{ dns_confdir }}/named.conf"
     validate: named-checkconf -zj %s
   notify:
-    - reload configuration
     - set dns_owner to owner of dns directory recursively
+    - reload configuration
 
 - name: start and enable dns
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,8 @@
   file:
     path: "{{ item }}"
     state: directory
+    owner: "{{ dns_owner }}"
+    group: "{{ dns_group }}"
   with_items:
     - "{{ dns_datadir }}"
     - "{{ dns_confdir }}"
@@ -54,8 +56,7 @@
   with_items:
     - "{{ dns_zones }}"
   notify:
-    - set dns_owner to owner of dns directory recursively
-    - reload zones
+    reload zones
   loop_control:
     label: "{{ item.name }}"
 
@@ -65,8 +66,7 @@
     dest: "{{ dns_confdir }}/named.conf"
     validate: named-checkconf -zj %s
   notify:
-    - set dns_owner to owner of dns directory recursively
-    - reload configuration
+    reload configuration
 
 - name: start and enable dns
   service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,9 +54,11 @@
   with_items:
     - "{{ dns_zones }}"
   notify:
-    reload zones
+    - reload zones
+    - set dns_owner to owner of dns directory recursively
   loop_control:
     label: "{{ item.name }}"
+    
 
 - name: add zones to configuration
   template:
@@ -64,7 +66,8 @@
     dest: "{{ dns_confdir }}/named.conf"
     validate: named-checkconf -zj %s
   notify:
-    reload configuration
+    - reload configuration
+    - set dns_owner to owner of dns directory recursively
 
 - name: start and enable dns
   service:


### PR DESCRIPTION
---
name: Allow dns_owner user to read and write dns directory
about: The dns_owner is not the owner of the dns_confdir. The bind9 service will not start up unless it has write access to that directory. 

---