### PR TITLE
Allow configuration of recursion and forwarders

### DIFF
--- a/templates/named.conf.j2
+++ b/templates/named.conf.j2
@@ -6,6 +6,20 @@ options {
   listen-on { any; };
   listen-on-v6 { any; };
   allow-query { any; };
+{% if dns_allow_recursion is defined %}
+  allow-recursion {
+{% for acl in dns_allow_recursion %}
+   {{ acl }}; 
+{% endfor %}
+  };
+{% endif %}
+{% if dns_options_forwarders is defined %}
+  forwarders {
+{% for options_forwarder in dns_options_forwarders %}
+    {{ options_forwarder }};
+{% endfor %}
+  };
+{% endif %}
 };
 
 {% if dns_caching_dns is defined %}
@@ -19,6 +33,13 @@ zone "." {
 zone "{{ zone.name }}" {
   type master;
   file "{{ dns_datadir }}/{{ zone.name }}.conf";
+{% if zone.dns_zone_forwarders is defined %}
+  forwarders {
+{% for zone_forwarder in zone.dns_zone_forwarders %}
+  "{{ zone_forwarder }}";
+{% endfor %}
+  };
+{% endif %}
 };
 {% endfor %}
 

--- a/templates/named.conf.j2
+++ b/templates/named.conf.j2
@@ -36,7 +36,7 @@ zone "{{ zone.name }}" {
 {% if zone.dns_zone_forwarders is defined %}
   forwarders {
 {% for zone_forwarder in zone.dns_zone_forwarders %}
-  "{{ zone_forwarder }}";
+    {{ zone_forwarder }};
 {% endfor %}
   };
 {% endif %}


### PR DESCRIPTION
---
name: Allow configuration of recursion and forwarders
about: Allow configuration of recursion and forwarders but leave these options off by default. 

---

**Describe the change**
Added some options to the template for named.conf which will add certain values if defined. 

Example usage:

  - name: example.com
    ttl: 604800
    ns:
      - name: dns1.example.com.
      - name: dns2.example.com.
    mx:
      - name: mail1.example.com.
        priority: 10
      - name: mail2.example.com.
        priority: 20
    records:
      - name: www
        value: 127.0.0.1
      - name: dns1
        value: 127.0.0.1
      - name: dns2
        value: 127.0.0.1
      - name: mail1
        value: 127.0.0.1
      - name: mail2
        value: 127.0.0.1
#Forward on requests in this zone to these addresses
    dns_zone_forwarders: 
      - "10.0.0.1"
      - "10.0.0.2"

# ACLs allowed to search recursively
dns_allow_recursion: 
  - "any"

# If this server doesn't have a specified zone, forward to this server
dns_options_forwarders:
  - "192.168.1.100"

**Testing**
Manual testing of each option included and excluded was performed and the validation from step "add zones to configuration" verified the changes were valid.
