### PR TITLE
Allow more bind options to be configurable.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -108,6 +108,9 @@ dns_options_listen_on_v6:
 #   - 'none'
 #   - '172.16.0.1'
 
+# An optional setting to congifure the path where the pid file will be created.
+# dns_pid_file: '/var/run/named/named.pid'
+
 # An optional setting to forward traffic to other DNS servers.
 # dns_options_forwarders:
 #   - 1.1.1.1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -88,6 +88,26 @@ dns_zones:
 dns_allow_recursion:
   - none
 
+# An optional list of IPv4 on which the DNS server will listen. ("any" and "none" are always available.)
+dns_options_listen_on:
+  - 'any'
+
+# A optional list of IPv6 on which the DNS server will listen. ("any" and "none" are always available.)
+dns_options_listen_on_v6:
+  - 'any'
+
+# An optional list of IP which are allowed to query the server. ("any" and "none" are always available.)
+# Default: "any"
+# dns_options_allow_query:
+#  - 'any'
+#  - '127.0.0.1'
+
+# An optional list of IP which are allowed to run a AXFR query. ("any" and "none" are always available.)
+# Default: "none"
+# dns_options_allow_transfer:
+#   - 'none'
+#   - '172.16.0.1'
+
 # An optional setting to forward traffic to other DNS servers.
 # dns_options_forwarders:
 #   - 1.1.1.1

--- a/templates/named.conf.j2
+++ b/templates/named.conf.j2
@@ -12,7 +12,7 @@ options {
   };
   listen-on-v6 {
 {% if dns_options_listen_on_v6 is defined %}
-  {{ dns_options_listen_v6 | join('\n') }}
+  {{ dns_options_listen_on_v6 | join('\n') }}
 {% else %}
     any;
 {% endif %}

--- a/templates/named.conf.j2
+++ b/templates/named.conf.j2
@@ -5,7 +5,7 @@ options {
   auth-nxdomain no;
   listen-on {
 {% if dns_options_listen_on is defined %}
-  {{ dns_options_listen | join('\n') }}
+  {{ dns_options_listen_on | join('\n') }}
 {% else %}
     any;
 {% endif %}

--- a/templates/named.conf.j2
+++ b/templates/named.conf.j2
@@ -3,9 +3,27 @@ options {
   directory "{{ dns_datadir }}";
   dnssec-validation auto;
   auth-nxdomain no;
-  listen-on { any; };
-  listen-on-v6 { any; };
-  allow-query { any; };
+  listen-on {
+{% if dns_options_listen_on is defined %}
+  {{ dns_options_listen | join('\n') }}
+{% else %}
+    any;
+{% endif %}
+  };
+  listen-on-v6 {
+{% if dns_options_listen_on_v6 is defined %}
+  {{ dns_options_listen_v6 | join('\n') }}
+{% else %}
+    any;
+{% endif %}
+  };
+  allow-query {
+{% if dns_options_allow_query is defined %}
+  {{ dns_options_allow_query | join('\n') }}
+{% else %}
+    any;
+{% endif %}
+  };
 {% if dns_allow_recursion is defined %}
   allow-recursion {
 {% for acl in dns_allow_recursion %}

--- a/templates/named.conf.j2
+++ b/templates/named.conf.j2
@@ -4,26 +4,22 @@ options {
   dnssec-validation auto;
   auth-nxdomain no;
   listen-on {
-{% if dns_options_listen_on is defined %}
-    {{ dns_options_listen_on | join(';\n    ') }}
-{% else %}
-    any;
-{% endif %}
+{% for ipv4 in dns_options_listen_on %}
+    {{ ipv4 }};
+{% endfor %}
   };
   listen-on-v6 {
-{% if dns_options_listen_on_v6 is defined %}
-    {{ dns_options_listen_on_v6 | join(';\n    ') }}
-{% else %}
-    any;
-{% endif %}
+{% for ipv6 in dns_options_listen_on_v6 %}
+    {{ ipv6 }};
+{% endfor %}
   };
-  allow-query {
 {% if dns_options_allow_query is defined %}
-    {{ dns_options_allow_query | join(';\n    ') }}
-{% else %}
-    any;
-{% endif %}
+  allow-query {
+{% for ip in dns_options_allow_query %}
+    {{ ip }};
+{% endfor %}
   };
+{% endif %}
 {% if dns_allow_recursion is defined %}
   allow-recursion {
 {% for acl in dns_allow_recursion %}
@@ -32,8 +28,10 @@ options {
   };
 {% endif %}
   allow-transfer {
-{% if dns_allow_transfer is defined %}
-    {{ dns_allow_transfer | join(';\n    ') }}
+{% if dns_options_allow_transfer is defined %}
+{% for ip in dns_options_allow_transfer %}
+    {{ ip }};
+{% endfor %}
 {% else %}
     none;
 {% endif %}

--- a/templates/named.conf.j2
+++ b/templates/named.conf.j2
@@ -1,6 +1,9 @@
 {{ ansible_managed | comment }}
 options {
   directory "{{ dns_datadir }}";
+{% if dns_pid_file is defined %}
+  pid-file "{{ dns_pid_file }}";
+{% endif %}
   dnssec-validation auto;
   auth-nxdomain no;
   listen-on {

--- a/templates/named.conf.j2
+++ b/templates/named.conf.j2
@@ -31,6 +31,13 @@ options {
 {% endfor %}
   };
 {% endif %}
+  allow-transfer {
+{% if dns_allow_transfer is defined %}
+    {{ dns_allow_transfer | join('\n') }}
+{% else %}
+    none;
+{% endif %}
+  };
 {% if dns_options_forwarders is defined %}
   forwarders {
 {% for options_forwarder in dns_options_forwarders %}

--- a/templates/named.conf.j2
+++ b/templates/named.conf.j2
@@ -5,21 +5,21 @@ options {
   auth-nxdomain no;
   listen-on {
 {% if dns_options_listen_on is defined %}
-  {{ dns_options_listen_on | join('\n') }}
+    {{ dns_options_listen_on | join(';\n    ') }}
 {% else %}
     any;
 {% endif %}
   };
   listen-on-v6 {
 {% if dns_options_listen_on_v6 is defined %}
-  {{ dns_options_listen_on_v6 | join('\n') }}
+    {{ dns_options_listen_on_v6 | join(';\n    ') }}
 {% else %}
     any;
 {% endif %}
   };
   allow-query {
 {% if dns_options_allow_query is defined %}
-  {{ dns_options_allow_query | join('\n') }}
+    {{ dns_options_allow_query | join(';\n    ') }}
 {% else %}
     any;
 {% endif %}
@@ -33,7 +33,7 @@ options {
 {% endif %}
   allow-transfer {
 {% if dns_allow_transfer is defined %}
-    {{ dns_allow_transfer | join('\n') }}
+    {{ dns_allow_transfer | join(';\n    ') }}
 {% else %}
     none;
 {% endif %}


### PR DESCRIPTION
name: Add more configurable options for `named.conf`
about: Add a few extra options for increased security allowing to setting values `listen-on`, `listen-on-v6`, `allow-query`, `allow-transfer` and `pid-file`.

---

**Describe the change**

This PR simply adds the possibility to configure a few more options in the `bind` main configuration.
This allow to deploy a more customised dns server, while retaining the "works-out-of-the-box" idea, because default values are set if no other config is used.

**Testing**

Currently manual testing on debian + alpine only as I could not get tox to do the testing properly.
