### PR TITLE
Fix deployment with disabled dns caching.

### DIFF
--- a/templates/named.conf.j2
+++ b/templates/named.conf.j2
@@ -48,7 +48,7 @@ options {
 {% endif %}
 };
 
-{% if dns_caching_dns is defined %}
+{% if dns_caching_dns is defined and dns_caching_dns | bool %}
 zone "." {
   type hint;
   file "{{ dns_datadir }}/named.root";


### PR DESCRIPTION
name: Fix deployment with disabled dns caching.
about: Allow deploying with root zone caching disabled.

---

Currently the template only checks if dns_caching_dns is set, so if you set it to False it will still
add the root zone caching.
Meanwhile the named.root file will be only downloaded if dns_caching_dns evaluates to true.
This means that if you set dns_caching_dns to false it will *not* download the named.root file, but
will be added to the named.conf, making it so that 'named-checkconf' will fail as it tries to load
a non existing file.

Error:
> could not configure root hints from '/var/bind/named.root': file not found

**Testing**

Only manual test on Alpine + Debian.
