### PR TITLE
Added lookup module cluster_dns to populate nameserver information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,14 +217,15 @@ dns_options_listen_on_v6:
 This module uses facter information to populate the nameserver information of dns_zones.
 
 Example usage:
-` dns_zones: "{{ lookup('cluster_dns', servers=groups['dns'], zones=my_zones, hostvars=hostvars, grouping='dns') }}"
 
-- lookup: This calls the lookup module.
--- cluster_dns: The module being called.
--- servers: a list of servers being used for DNS.  The above example uses the inventory group DNS.
--- zones: dns_zone variable needing nameserver information.  
--- hostvars: hostvars.  This variable is created when the playbook is run.  It contains the needed IP information.
--- grouping: (Optional) places all of the dns ips behind a single name.  Useful if DNS server is also NTP, Consul...
+```dns_zones: "{{ lookup('cluster_dns', servers=groups['dns'], zones=my_zones, hostvars=hostvars, grouping='dns') }}"```
+
+* lookup: This calls the lookup module.
+** cluster_dns: The module being called.
+** servers: a list of servers being used for DNS.  The above example uses the inventory group DNS.
+** zones: dns_zone variable needing nameserver information.  
+** hostvars: hostvars.  This variable is created when the playbook is run.  It contains the needed IP information.
+** grouping: (Optional) places all of the dns ips behind a single name.  Useful if DNS server is also NTP, Consul...
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -221,11 +221,11 @@ Example usage:
 ```dns_zones: "{{ lookup('cluster_dns', servers=groups['dns'], zones=my_zones, hostvars=hostvars, grouping='dns') }}"```
 
 * lookup: This calls the lookup module.
-** cluster_dns: The module being called.
-** servers: a list of servers being used for DNS.  The above example uses the inventory group DNS.
-** zones: dns_zone variable needing nameserver information.  
-** hostvars: hostvars.  This variable is created when the playbook is run.  It contains the needed IP information.
-** grouping: (Optional) places all of the dns ips behind a single name.  Useful if DNS server is also NTP, Consul...
+ * cluster_dns: The module being called.
+ * servers: a list of servers being used for DNS.  The above example uses the inventory group DNS.
+ * zones: dns_zone variable needing nameserver information.  
+ * hostvars: hostvars.  This variable is created when the playbook is run.  It contains the needed IP information.
+ * grouping: (Optional) places all of the dns ips behind a single name.  Useful if DNS server is also NTP, Consul...
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,20 @@ dns_options_listen_on_v6:
 #       - 8.8.8.8
 ```
 
+## Lookup module: cluster_dns
+
+This module uses facter information to populate the nameserver information of dns_zones.
+
+Example usage:
+` dns_zones: "{{ lookup('cluster_dns', servers=groups['dns'], zones=my_zones, hostvars=hostvars, grouping='dns') }}"
+
+- lookup: This calls the lookup module.
+-- cluster_dns: The module being called.
+-- servers: a list of servers being used for DNS.  The above example uses the inventory group DNS.
+-- zones: dns_zone variable needing nameserver information.  
+-- hostvars: hostvars.  This variable is created when the playbook is run.  It contains the needed IP information.
+-- grouping: (Optional) places all of the dns ips behind a single name.  Useful if DNS server is also NTP, Consul...
+
 ## Requirements
 
 - Access to a repository containing packages, likely on the internet.

--- a/lookup_plugins/cluster_dns.py
+++ b/lookup_plugins/cluster_dns.py
@@ -1,0 +1,69 @@
+# (c) 2013, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    lookup: random_choice
+    author: Michael DeHaan <michael.dehaan@gmail.com>
+    version_added: "1.1"
+    short_description: return random element from list
+    description:
+        - The 'random_choice' feature can be used to pick something at random. While it's not a load balancer (there are modules for those),
+          it can somewhat be used as a poor man's load balancer in a MacGyver like situation.
+        - At a more basic level, they can be used to add chaos and excitement to otherwise predictable automation environments.
+"""
+
+EXAMPLES = """
+- name: Magic 8 ball for MUDs
+  debug:
+    msg: "{{ item }}"
+  with_random_choice:
+    - "go through the door"
+    - "drink from the goblet"
+    - "press the red button"
+    - "do nothing"
+"""
+
+RETURN = """
+  _raw:
+    description:
+      - random item
+"""
+import random
+
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_native
+from ansible.plugins.lookup import LookupBase
+
+class LookupModule(LookupBase):
+
+    def run(self, terms=None, servers=None, zones=None, hostvars=None, grouping=None, **kwargs):
+        ret = zones
+        for zone in zones:
+            zone['ns'] = []
+            for server in servers:
+                zone['ns'].append({'name': f'{hostvars[server]["ansible_hostname"]}.{zone["name"]}.'})
+            if not 'records' in zone:
+                zone['records'] = []
+            for server in servers:
+                if hostvars[server]['ansible_default_ipv4']:
+                    zone['records'].append({
+                        'name': hostvars[server]["ansible_hostname"],
+                        'value': hostvars[server]['ansible_default_ipv4']['address']})
+                    if grouping:
+                        zone['records'].append({
+                            'name': grouping,
+                            'value': hostvars[server]['ansible_default_ipv4']['address']})
+                if hostvars[server]['ansible_default_ipv6']:
+                    zone['records'].append({
+                        'name': hostvars[server]["ansible_hostname"],
+                        'type': 'AAAA',
+                        'value': hostvars[server]['ansible_default_ipv6']['address']})
+                    if grouping:
+                        zone['records'].append({
+                            'name': grouping,
+                            'type': 'AAAA',
+                            'value': hostvars[server]['ansible_default_ipv6']['address']})
+        return ret


### PR DESCRIPTION
---
name: Adding lookup module.
about: Used to populate nameserver information from facts.

---

**Describe the change**
This adds a ansible lookup module called cluster_dns.  It can be used to pull the information gathered by factor, and populate the dns_zone nameserver variables.

**Testing**
Not sure how to setup tests for a lookup.  I'm willing to set them up with a little guidance.  