### PR TITLE
Add dns_root_hints_url to configure the URL to download the root hints file

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,10 @@ dns_pid_file: /run/named/named.pid
 # dns_forwarders:
 #   - "1.1.1.1"
 #   - "8.8.8.8"
+
+# An optional setting to specify the URL to download the root hints file,
+# containing a list of authoritative root DNS servers.
+dns_root_hints_url: https://www.internic.net/domain/named.root
 ```
 
 ## [Requirements](#requirements)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,3 +80,7 @@ dns_pid_file: /run/named/named.pid
 # dns_forwarders:
 #   - "1.1.1.1"
 #   - "8.8.8.8"
+
+# An optional setting to specify the URL to download the root hints file,
+# containing a list of authoritative root DNS servers.
+dns_root_hints_url: https://www.internic.net/domain/named.root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,7 @@
 
 - name: Get the hints/root file
   ansible.builtin.get_url:
-    url: "https://www.internic.net/domain/named.root"
+    url: "{{ dns_root_hints_url }}"
     dest: "{{ dns_datadir }}/named.root"
     validate_certs: "{{ dns_validate_certs }}"
     mode: "0640"


### PR DESCRIPTION
name: Add `dns_root_hints_url` to configure the URL to download the root hints file
about: Add an extra option to allow to configure the URL to download the root hints file

---

**Describe the change**

This PR introduces an optional setting, `dns_root_hints_url`, which allows users to specify a custom URL from which to download the root hints file.

This is particularly useful in environments with restricted internet access, as it allows administrators to specify a locally accessible URL or an internal proxy that can provide the root hints file.

**Testing**

Manually tested on a Debian server.