### PR TITLE
Use correct variable name for dns_forwarders

### DIFF
--- a/templates/named.conf.j2
+++ b/templates/named.conf.j2
@@ -39,9 +39,9 @@ options {
     none;
 {% endif %}
   };
-{% if forwarders is defined %}
+{% if dns_forwarders is defined %}
   forwarders {
-{% for forwarder in forwarders %}
+{% for forwarder in dns_forwarders %}
     {{ forwarder }};
 {% endfor %}
   };


### PR DESCRIPTION
Fixes variable for forwarders in config template.

Issue #15 